### PR TITLE
Update map.monkey2

### DIFF
--- a/collections/map.monkey2
+++ b/collections/map.monkey2
@@ -509,7 +509,7 @@ Class Map<K,V>
 		Return True
 	End
 
-	#rem wonkeydoc Union: Add each keys from this (param) that exist in self
+	#rem monkeydoc Union: Add each keys from this (param) that exist in self
 	@param This The map to compare.
 	@param onPlace if False, returns a copy of the map, else nothing
 	#end
@@ -518,7 +518,7 @@ Class Map<K,V>
 		Return Union(this,onPlace)
 	End
 
-	#rem wonkeydoc Union: Add each keys from this (param) that exist in self
+	#rem monkeydoc Union: Add each keys from this (param) that exist in self
 	@param This The map to compare.
 	@param onPlace if False, returns a copy of the map, else nothing
 	#end	
@@ -537,7 +537,7 @@ Class Map<K,V>
 		Return result
 	End 
 
-	#rem wonkeydoc Intersect: Keep all keys from self that exist in this (param)
+	#rem monkeydoc Intersect: Keep all keys from self that exist in this (param)
 	@param This The map to compare.
 	@param onPlace if False, returns a copy of the map, else nothing
 	#end	
@@ -556,7 +556,7 @@ Class Map<K,V>
 		Return result	
 	End
 
-	#rem wonkeydoc Difference: Remove all keys from self that exist in this (param)
+	#rem monkeydoc Difference: Remove all keys from self that exist in this (param)
 	@param This The map to compare.
 	@param onPlace if False, returns a copy of the map, else nothing
 	#end


### PR DESCRIPTION
----------------
Map, List, Stack
----------------

	MAP RANGE x2 (Undoned):
		Map can only works with 32 unigned integer

	POINTER:
		Pointers are back.
		There was a problem with pointers to classes, Node as a class of course, but also K and V (internals).
		This problem is now fixed.

	KEY AS Uint, Long and ULong: UNDONED
		Method ToMapUInt:Map<UInt,T>( defValue:UInt=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method ToMapLong:Map<Long,T>( defValue:Long=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method ToMapULong:Map<ULong,T>( defValue:ULong=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T2,T>, onPlace:Bool=True ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T,T2>, onPlace:Bool=True ) 'Added by iDkP
		Method ToMapByte:Map<T,Byte>( defValue:Byte=Null, populateWithIdx:Bool=False ) 'Added by iDkP

	Conversions who works:
		Operator To:Map<T,UInt>() 'Added by iDkP
		Method ToMapUByte:Map<T,UByte>( defValue:UByte=Null, populateWithIdx:Bool=False ) 'Added by iDkP

		Because T is a 32-bit internal pointer (the node) and is a signed integer, so T and Int work, but not Uint, Long, and ULong.		
		The C transpiler can't handle UInt, Long, and ULong as keys for Map (not my fault).

		This was a workaround:
			Overloading for operator doesn't works with integrated code while it works perfectly as an extension code.
			https://discord.com/channels/796336780302876683/850292419781459988/1371074708933574756

	Conversions that should works but no (do not working in debug mode only)
		Method ToMapInt:Map<Int,T>( defValue:Int=Null, populateWithIdx:Bool=False ) 'Added by iDkP

		Not specific reason found.

	Works:
		Property HasOne:Bool() 'Added by iDkP
		Property HasTwo:Bool() 'Added by iDkP
		Property HasOneOrTwo:Byte() 'Added by iDkP
		Method HasLess:Bool( nbItems:UInt ) 'Added by iDkP
		Method HasMore:Bool( nbItems:UInt ) 'Added by iDkP
		Operator To:Map<T,UInt>() 'Added by iDkP
		Method ToMapByte:Map<T,Byte>( defValue:Byte=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method ToMapUByte:Map<T,UByte>( defValue:UByte=Null, populateWithIdx:Bool=False ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T2,T>, onPlace:Bool=True ) 'Added by iDkP
		Method FromMap<T2>:List<T>( map:Map<T,T2>, onPlace:Bool=True ) 'Added by iDkP
		Method ToMapInt:Map<Int,T>( defValue:Int=Null, populateWithIdx:Bool=False ) 'Added by iDkP

	The sort filter was not the cause of the problem. 
	The set of combinatorial functions was not the cause of the problem.

----------------
Mojo 3d
----------------

	Changed in sdk_mojo\graphics\mojo3d\render\spritebuffer
	Changed in mojo3d\render\spritebuffer
	Line 24 
	Line 29
	UInt related
	Now the virtual buffer object can handles potentially ~4B vertices

----------------
Ted2go/Wide
----------------

	Changed in wide/view/ListViewExt
	64	_visibleCount=Min( _maxLines,Int(_items.Length) ) ' Modified by idkP
	71	_visibleCount=Min( _maxLines,Int(_items.Length) ) ' Modified by idkP
	78	_visibleCount=Min( _maxLines, Int(_items.Length) ) ' Modified by idkP
	247	Local lastVisLine:=Min( (clip.Bottom-1)/_lineH,Int(_items.Length) ) 'Modified by idkP
	264	Local lastVisLine:=Min( (clip.Bottom-1)/_lineH,Int(_items.Length) ) 'Modified by idkP

	Min/Max Functions Since the current formats are not overloaded with different types, 
	the element length has been adjusted to a signed integer, as it's impossible to store 
	more than 4B of views in software!
	This way, Ted2/Wide's view count is now memory-efficient.

	In this order of idea, I'm wondering if it wouldn't be better to choose UShort 
	since we can't easily view more than 16,000 views in an application.
	We need to change the holder.

Working time for this analysis and debugging: 9pm -> 5am (8 hours uninterrupted)

Since the upload of seyhajin@gmail.com the map wasn't updated.